### PR TITLE
Recognize file paths with slashes in get_file route.

### DIFF
--- a/signac_dashboard/dashboard.py
+++ b/signac_dashboard/dashboard.py
@@ -408,7 +408,7 @@ class Dashboard:
         self.url('views.search', ['/search'])
         self.url('views.jobs_list', ['/jobs/'])
         self.url('views.show_job', ['/jobs/<jobid>'])
-        self.url('views.get_file', ['/jobs/<jobid>/file/<filename>'])
+        self.url('views.get_file', ['/jobs/<jobid>/file/<path:filename>'])
         self.url('views.change_modules', ['/modules'], methods=['POST'])
 
     def main(self):


### PR DESCRIPTION
Fetching files in job workspace subdirectories caused failures because the slashes weren't being captured in the route. This snippet describes the solution: http://flask.pocoo.org/snippets/76/