### PR TITLE
Fix glob paths to be relative instead of basenames

### DIFF
--- a/signac_dashboard/modules/image_viewer.py
+++ b/signac_dashboard/modules/image_viewer.py
@@ -34,4 +34,4 @@ class ImageViewer(Module):
                        for image_glob in self.img_globs]
         image_files = itertools.chain(*image_globs)
         for filepath in image_files:
-            yield make_card(os.path.basename(filepath))
+            yield make_card(os.path.relpath(filepath, job.ws))

--- a/signac_dashboard/modules/video_viewer.py
+++ b/signac_dashboard/modules/video_viewer.py
@@ -45,4 +45,4 @@ class VideoViewer(Module):
                        for video_glob in self.video_globs]
         video_files = itertools.chain(*video_globs)
         for filepath in video_files:
-            yield make_card(os.path.basename(filepath))
+            yield make_card(os.path.relpath(filepath, job.ws))


### PR DESCRIPTION
This fixes an issue where Image Viewer and Video Viewer modules were using `os.path.basename` instead of returning the relative path. Previously it only worked for images/videos in the job workspace root. This fixes the behavior for matches images/videos in subdirectories.