### PR TITLE
Wrap words in the card content.

### DIFF
--- a/signac_dashboard/static/scss/app.scss
+++ b/signac_dashboard/static/scss/app.scss
@@ -58,10 +58,13 @@ body {
 section.section.panel {
   padding: 1rem 1.5rem;
 }
+.card {
+  word-wrap: break-word;
+}
 .card-header-title.card-header-dashboard {
   display: block;
   background-color: whitesmoke;
 }
 .hero .tabs ul {
-    border-bottom: 1px solid #d3d6db;
+  border-bottom: 1px solid #d3d6db;
 }


### PR DESCRIPTION
@csadorf noticed that some very long statepoint parameters weren't being wrapped, and were hidden behind other cards' content. This PR resolves that behavior by adding the CSS `word-wrap: break-work;`.

Example with word-wrap:
![image](https://user-images.githubusercontent.com/3943761/56702667-3c75da80-66d3-11e9-88d7-b13a5e240bf1.png)
