### PR TITLE
Add WSGI support.

### DIFF
--- a/examples/wsgi/.gitignore
+++ b/examples/wsgi/.gitignore
@@ -1,0 +1,3 @@
+signac.rc
+signac_project_document.json
+workspace/

--- a/examples/wsgi/README.md
+++ b/examples/wsgi/README.md
@@ -1,0 +1,12 @@
+# WSGI Example
+
+This example shows how to use a dashboard with WSGI, using `gunicorn`.
+
+To run this example, `pip install gunicorn` and then execute
+
+```bash
+python init.py  # Create the signac data space
+./gunicorn_serve.sh
+```
+
+See the `gunicorn` documentation for more examples.

--- a/examples/wsgi/dashboard.py
+++ b/examples/wsgi/dashboard.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 The Regents of the University of Michigan
+# All rights reserved.
+# This software is licensed under the BSD 3-Clause License.
+from signac_dashboard import Dashboard
+from signac_dashboard.modules import StatepointList
+
+# To use multiple workers, a single shared key must be used. By default, the
+# secret key is randomly generated at runtime by each worker. Using a provided
+# shared key allows sessions to be shared across workers. This key was
+# generated with os.urandom(16)
+config = {
+    'SECRET_KEY': b"\x99o\x90'/\rK\xf5\x10\xed\x8bC\xaa\x03\x9d\x99"
+}
+
+modules = [
+    StatepointList(),
+]
+
+# The dashboard instance must be importable by the WSGI server.
+dashboard = Dashboard(config=config, modules=modules)

--- a/examples/wsgi/gunicorn_serve.sh
+++ b/examples/wsgi/gunicorn_serve.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Copyright (c) 2019 The Regents of the University of Michigan
+# All rights reserved.
+# This software is licensed under the BSD 3-Clause License.
+gunicorn --workers 8 --bind localhost:8888 dashboard:dashboard

--- a/examples/wsgi/init.py
+++ b/examples/wsgi/init.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 The Regents of the University of Michigan
+# All rights reserved.
+# This software is licensed under the BSD 3-Clause License.
+from signac import init_project
+
+project = init_project('dashboard-test-project')
+
+for a in range(10):
+    for b in range(10):
+        project.open_job({'a': a, 'b': b}).init()

--- a/signac_dashboard/dashboard.py
+++ b/signac_dashboard/dashboard.py
@@ -46,6 +46,10 @@ class Dashboard:
       :code:`True` (default: :code:`False`).
     - **PER_PAGE**: Maximum number of jobs to show per page
       (default: 25).
+    - **SECRET_KEY**: This must be specified to run via WSGI with multiple
+      workers, so that sessions remain intact. See the
+      `Flask docs <http://flask.pocoo.org/docs/1.0/config/#SECRET_KEY>`_
+      for more information.
 
     :param config: Configuration dictionary (default: :code:`{}`).
     :type config: dict
@@ -500,6 +504,10 @@ class Dashboard:
         for func in filter(lambda f: hasattr(f, 'cache_clear'),
                            map(lambda x: x[1], members)):
             func.cache_clear()
+
+    def __call__(self, environ, start_response):
+        """Call the dashboard as a WSGI application."""
+        return self.app(environ, start_response)
 
     def main(self):
         """Runs the command line interface.


### PR DESCRIPTION
WSGI is how Flask applications are meant to be run in production. When using `signac-dashboard` with the built-in Flask `app.run()` command, this notice appears:

```
 * Environment: production
   WARNING: Do not use the development server in a production environment.
   Use a production WSGI server instead.
```

This PR exposes the Flask application's support for WSGI directly, so that servers like [gunicorn](https://gunicorn.org/), [bjoern](https://github.com/jonashaag/bjoern), or [CherryPy](https://cherrypy.org/) can be used to host the dashboard. This is supposed to be much faster and more reliable - in particular, some servers like gunicorn support multithreading and multiple workers which should scale well for handling I/O-intensive or CPU-intensive module workloads.