### PR TITLE
Fix/disable where

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,11 +57,6 @@ jobs:
     docker:
       - image: circleci/python:3.5-jessie
 
-  test-3.4:
-    <<: *test-template
-    docker:
-      - image: circleci/python:3.4-jessie
-
   test-pypy-3:
     <<: *test-template
     docker:
@@ -97,9 +92,6 @@ workflows:
   style-check-and-tests:
     jobs:
       - style-check
-      - test-3.4:
-          requires:
-            - style-check
       - test-3.5:
           requires:
             - style-check
@@ -114,7 +106,6 @@ workflows:
             branches:
               only: /release\/.*/
           requires:
-            - test-3.4
             - test-3.5
             - test-3.7
             - test-pypy-3

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Built on top of the **signac** framework, **signac-dashboard** allows users to r
 ## Installation
 
 The recommended installation method for **signac-dashboard** is through **conda** or **pip**.
-The software is tested for Python 3.4+ and is built for all major platforms.
+The software is tested for Python 3.5+ and is built for all major platforms.
 
 To install **signac-dashboard** *via* the [conda-forge](https://conda-forge.github.io/) channel, execute:
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -16,7 +16,7 @@ Added
 
 Changed
 +++++++
-- Disabled $where operations in search queries by default for security.
+- Disabled $where operations in search queries by default, see :ref:`dashboard-security`.
 
 Version 0.2
 ===========

--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,10 @@ Added
 +++++
 - Method for clearing dashboard and project caches.
 
+Changed
++++++++
+- Disabled $where operations in search queries by default for security.
+
 Version 0.2
 ===========
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -1,4 +1,4 @@
-.. _api:
+.. _dashboard-api:
 
 API Reference
 =============

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -22,6 +22,7 @@ Contents
 
    installation
    api
+   security
    changes
    support
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -5,7 +5,7 @@ Installation
 ============
 
 The recommended installation method for **signac-dashboard** is via conda_ or pip_.
-The software is tested for Python versions 3.4+. Its primary dependencies are signac_ and flask_.
+The software is tested for Python versions 3.5+. Its primary dependencies are signac_ and flask_.
 
 .. _conda: https://conda.io/
 .. _conda-forge: https://conda-forge.org/

--- a/doc/security.rst
+++ b/doc/security.rst
@@ -1,0 +1,10 @@
+.. _dashboard-security:
+
+Security Guidelines
+-------------------
+
+By default, the **signac-dashboard** application only listens to HTTP requests from :code:`localhost`, on port 8888.
+Running the **signac-dashboard** Flask server with a configuration that makes it publicly accessible presents a critical security risk.
+For example, user-implemented modules may not be safe-guarded against arbitrary code execution.
+To enable remote access, use `secure port forwarding via SSH <dashboard-remote-ssh>`_.
+The use of the :code:`$where` operation in searches is disabled by default and must be `explicitly enabled <python-api-dashboard>`_, in which case the dashboard is vulnerable against `code-injection attacks <https://en.wikipedia.org/wiki/Code_injection>`_.

--- a/doc/support.rst
+++ b/doc/support.rst
@@ -1,4 +1,4 @@
-.. _support:
+.. _dashboard-support:
 
 Support and Development
 -----------------------

--- a/signac_dashboard/dashboard.py
+++ b/signac_dashboard/dashboard.py
@@ -301,7 +301,8 @@ class Dashboard:
         if '$where' in query and not self.config.get('ALLOW_WHERE', False):
             flash('Searches using $where allow arbitrary code execution and '
                   'are only allowed when the configuration option '
-                  '\'ALLOW_WHERE\' is enabled.', 'warning')
+                  '\'ALLOW_WHERE\' is enabled. See also: <a href="https://docs.signac.io/projects/dashboard/en/latest/security.html">Security Guidelines</a>',  # noqa:E501
+                  'warning')
             raise RuntimeError('ALLOW_WHERE must be enabled for this query.')
 
         querytype = 'statepoint'

--- a/signac_dashboard/templates/layout.html
+++ b/signac_dashboard/templates/layout.html
@@ -135,7 +135,7 @@
                     {% with messages = get_flashed_messages(with_categories=true) %}
                     {% if messages %}
                     {% for category, message in messages %}
-                    <div class="notification is-{{ category }}">{{ message }}</div>
+                    <div class="notification is-{{ category }}">{{ message | safe }}</div>
                     {% endfor %}
                     {% endif %}
                     {% endwith %}

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -62,6 +62,23 @@ class DashboardTestCase(unittest.TestCase):
         response = str(rv.get_data())
         assert '{} jobs'.format(true_num_jobs) in response
 
+    def test_allow_where_search(self):
+        dictquery = {'sum': 1}
+        true_num_jobs = len(list(self.project.find_jobs(doc_filter=dictquery)))
+        query = urlquote('doc:sum.$where "lambda x: x == 1"')
+
+        self.dashboard.config['ALLOW_WHERE'] = False
+        rv = self.test_client.get('/search?q={}'.format(query),
+                                  follow_redirects=True)
+        response = str(rv.get_data())
+        assert 'ALLOW_WHERE must be enabled for this query.' in response
+
+        self.dashboard.config['ALLOW_WHERE'] = True
+        rv = self.test_client.get('/search?q={}'.format(query),
+                                  follow_redirects=True)
+        response = str(rv.get_data())
+        assert '{} jobs'.format(true_num_jobs) in response
+
 
 class AllModulesTestCase(DashboardTestCase):
 


### PR DESCRIPTION
Disables `$where` operations in search queries by default, to prevent arbitrary code execution.