### PR TITLE
Feature/auto clear caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build/
 dist/
 .signac_sp_cache.json.gz
 doc/_*
+.signac_shell_history

--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,11 @@ The **signac-dashboard** package follows `semantic versioning <https://semver.or
 Version 0.2
 ===========
 
+next
+----
+
+- Automatically clear caches upon changes of the project's workspace, e.g. initialization, migration, or removal of jobs.
+
 [0.2.4] -- 2019-05-23
 ---------------------
 

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         'libsass',
         'jsmin',
         'natsort',
+        'watchdog',
     ],
 
     classifiers=[

--- a/signac_dashboard/dashboard.py
+++ b/signac_dashboard/dashboard.py
@@ -616,11 +616,6 @@ class Dashboard:
         try:
             self.observer.start()
             args.func(args)
-        except KeyboardInterrupt:
-            logger.error("Interrupted.")
-            if args.debug:
-                raise
-            sys.exit(1)
         except RuntimeWarning as warning:
             logger.warning("Warning: {}".format(warning))
             if args.debug:

--- a/signac_dashboard/dashboard.py
+++ b/signac_dashboard/dashboard.py
@@ -631,8 +631,6 @@ class Dashboard:
             if args.debug:
                 raise
             sys.exit(1)
-        else:
-            sys.exit(0)
         finally:
             self.observer.stop()
             self.observer.join()

--- a/signac_dashboard/dashboard.py
+++ b/signac_dashboard/dashboard.py
@@ -275,7 +275,7 @@ class Dashboard:
                     s.append('{}={}'.format('.'.join(keys), _format_num(v)))
             return ' '.join(s)
         except Exception as error:
-            logger.warning(
+            logger.debug(
                 "Error while generating job title: '{}'. "
                 "Returning job-id as fallback.".format(error))
             return str(job)

--- a/signac_dashboard/dashboard.py
+++ b/signac_dashboard/dashboard.py
@@ -37,11 +37,7 @@ class _FileSystemEventHandler(FileSystemEventHandler):
     def on_modified(self, event):
         if os.path.realpath(event.src_path) == \
                 os.path.realpath(self.dashboard.project.workspace()):
-            self.dashboard._project_basic_index.cache_clear()
-            self.dashboard._schema_variables.cache_clear()
-            self.dashboard._project_min_len_unique_id.cache_clear()
-            self.dashboard._get_all_jobs.cache_clear()
-            self.dashboard._job_search.cache_clear()
+            self.dashboard.update_cache()
 
 
 class Dashboard:
@@ -521,7 +517,6 @@ class Dashboard:
         altered, this method may need to be called before the dashboard
         reflects those changes.
         """
-
         # Try to update signac project cache. Requires signac 0.9.2 or later.
         with warnings.catch_warnings():
             warnings.simplefilter(action='ignore', category=FutureWarning)


### PR DESCRIPTION
## Description

Install a file system observer to watch for changes within the workspace directory, upon which all dashboard caches are automatically cleared.

## Motivation and Context

I got annoyed with the need to restart my dashboard every single time I added or removed jobs from the workspace.

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-dashboard/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-dashboard/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-dashboard/blob/master/contributors.txt).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-dashboard/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-dashboard/blob/master/changelog.txt).
