### PR TITLE
Clarify missing markdown library error message.

### DIFF
--- a/signac_dashboard/modules/text_display.py
+++ b/signac_dashboard/modules/text_display.py
@@ -49,7 +49,7 @@ class TextDisplay(Module):
                 msg = Markup(markdown.markdown(
                     msg, extensions=['markdown.extensions.attr_list']))
             else:
-                msg = ('Error: Must install markdown library to render '
-                       'Markdown.')
+                msg = ("Error: Install the 'markdown' library to render "
+                       "Markdown.")
         return [{'name': self.name,
                  'content': render_template(self.template, msg=msg)}]


### PR DESCRIPTION
Slightly update the error message, I found the previous message not very helpful.

I needed to check the source code to understand that I actually need to install a package called 'markdown'.