### PR TITLE
Add route for /favicon.ico to remove 404 errors from browsers' automatic requests.

### DIFF
--- a/signac_dashboard/dashboard.py
+++ b/signac_dashboard/dashboard.py
@@ -488,6 +488,10 @@ class Dashboard:
         def page_not_found(error):
             return self._render_error(str(error))
 
+        @dashboard.app.route('/favicon.ico')
+        def favicon():
+            return url_for('static', filename='favicon.ico')
+
         self.add_url('views.home', ['/'])
         self.add_url('views.settings', ['/settings'])
         self.add_url('views.search', ['/search'])


### PR DESCRIPTION
## Description
Super minor fix, merging when tests pass. Browsers automatically request `/favicon.ico` from webpages they visit. This adds a static route that points to the included favicon, to prevent 404 errors from appearing in the log.

```
127.0.0.1 - - [14/Sep/2020 22:10:16] "GET /favicon.ico HTTP/1.1" 200 -
404 Not Found: The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again.
```

## Types of Changes
<!-- Please select all items that apply either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-dashboard/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-dashboard/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-dashboard/blob/master/contributors.txt).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-dashboard/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-dashboard/blob/master/changelog.txt).
