### PR TITLE
Add sphinx-codeautolink extension to docs.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -189,11 +189,11 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/", None),
+    "python": ("https://docs.python.org/3/", None),
     "signac-docs": ("https://docs.signac.io/en/latest/", None),
     "signac": ("https://docs.signac.io/projects/core/en/latest/", None),
     "flow": ("https://docs.signac.io/projects/flow/en/latest/", None),
-    "flask": ("http://flask.pocoo.org/docs/", None),
+    "flask": ("https://flask.palletsprojects.com/", None),
     "werkzeug": ("https://werkzeug.palletsprojects.com/", None),
 }
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -45,6 +45,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
+    "sphinx_codeautolink",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -6,7 +6,7 @@ Signac-dashboard package documentation
     This is documentation for the **signac-dashboard** package, which is part of the signac_ framework.
     See `here <signac-docs_>`_ for a comprehensive introduction to the **signac** *framework*.
 
-.. _signac: http://www.signac.io/
+.. _signac: https://signac.io/
 .. _signac-docs: https://docs.signac.io/
 
 Contents

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -8,11 +8,11 @@ The recommended installation method for **signac-dashboard** is via conda_ or pi
 The software is tested for Python versions 3.6+. Its primary dependencies are signac_ and flask_.
 Supported Python and NumPy versions are determined according to the `NEP 29 deprecation policy <https://numpy.org/neps/nep-0029-deprecation_policy.html>`_.
 
-.. _conda: https://conda.io/
+.. _conda: https://docs.conda.io/
 .. _conda-forge: https://conda-forge.org/
-.. _pip: https://pip.pypa.io/en/stable/
-.. _signac: http://www.signac.io/
-.. _flask: http://flask.pocoo.org/
+.. _pip: https://pip.pypa.io/
+.. _signac: https://signac.io/
+.. _flask: https://flask.palletsprojects.com/
 
 Install with conda
 ==================

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,3 @@
 sphinx>=4.0.0
 sphinx_rtd_theme>=1.0.0
+sphinx-codeautolink>=0.10.0

--- a/signac_dashboard/modules/flow_status.py
+++ b/signac_dashboard/modules/flow_status.py
@@ -19,7 +19,7 @@ class FlowStatus(Module):
 
     .. code-block:: python
 
-        from project import Project  # FlowProject subclass with labels
+        from project import Project  # Project is a FlowProject with labels
         from signac_dashboard import Dashboard
 
         if __name__ == '__main__':
@@ -41,8 +41,8 @@ class FlowStatus(Module):
         self.project = dashboard.project
         if not hasattr(self.project, "labels"):
             logger.warning(
-                "The provided signac Project cannot provide labels."
-                " Try providing a FlowProject to the Dashboard's "
+                "The provided signac Project cannot provide labels. "
+                "Try providing a FlowProject to the Dashboard's "
                 "project argument."
             )
 

--- a/signac_dashboard/modules/text_display.py
+++ b/signac_dashboard/modules/text_display.py
@@ -22,8 +22,10 @@ class TextDisplay(Module):
 
     .. code-block:: python
 
+        from signac_dashboard.modules import TextDisplay
+
         def my_text(job):
-            return 'This job id is {}.'.format(str(job))
+            return f"This job id is {job}."
 
         modules = [TextDisplay(message=my_text)]
 
@@ -59,5 +61,5 @@ class TextDisplay(Module):
                     markdown.markdown(msg, extensions=["markdown.extensions.attr_list"])
                 )
             else:
-                msg = "Error: Install the 'markdown' library to render " "Markdown."
+                msg = "Error: Install the 'markdown' library to render Markdown."
         return [{"name": self.name, "content": render_template(self.template, msg=msg)}]


### PR DESCRIPTION
## Description
Added sphinx-codeautolink extension. https://sphinx-codeautolink.readthedocs.io/en/latest/

Minor updates to documentation.

## Motivation and Context
Related: https://github.com/glotzerlab/signac-docs/issues/103

## Types of Changes
- [x] Documentation update

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-dashboard/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-dashboard/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-dashboard/blob/master/contributors.txt).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-dashboard/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-dashboard/blob/master/changelog.txt).
