### PR TITLE
Use send_from_directory for safety.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,14 @@ The **signac-dashboard** package follows `semantic versioning <https://semver.or
 Version 0.2
 ===========
 
+[0.2.9] -- 2022-02-08
+---------------------
+
+Fixed
++++++
+
+- Use Flask's ``send_from_directory`` for safety (#111).
+
 [0.2.8] -- 2021-05-26
 ---------------------
 

--- a/signac_dashboard/modules/image_viewer.py
+++ b/signac_dashboard/modules/image_viewer.py
@@ -56,4 +56,4 @@ class ImageViewer(Module):
         ]
         image_files = itertools.chain(*image_globs)
         for filepath in image_files:
-            yield make_card(os.path.relpath(filepath, job.ws))
+            yield make_card(os.path.relpath(filepath, job.workspace()))

--- a/signac_dashboard/modules/video_viewer.py
+++ b/signac_dashboard/modules/video_viewer.py
@@ -87,4 +87,4 @@ class VideoViewer(Module):
         ]
         video_files = itertools.chain(*video_globs)
         for filepath in video_files:
-            yield make_card(os.path.relpath(filepath, job.ws))
+            yield make_card(os.path.relpath(filepath, job.workspace()))

--- a/signac_dashboard/views.py
+++ b/signac_dashboard/views.py
@@ -11,7 +11,7 @@ from flask import (
     redirect,
     render_template,
     request,
-    send_file,
+    send_from_directory,
     session,
     url_for,
 )
@@ -79,8 +79,9 @@ def get_file(dashboard, jobid, filename):
             for regex in textfile_regexes:
                 if re.match(regex, filename) is not None:
                     mimetype = "text/plain"
-            return send_file(
-                job.fn(filename),
+            return send_from_directory(
+                job.workspace(),
+                filename,
                 mimetype=mimetype,
                 cache_timeout=cache_timeout,
                 conditional=True,


### PR DESCRIPTION
## Description
Uses Flask's `send_from_directory` for safety. Users are recommended to upgrade.

## Motivation and Context
Closes a potential security hole.

## Types of Changes
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality.

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-dashboard/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-dashboard/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-dashboard/blob/master/contributors.txt).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-dashboard/blob/master/CONTRIBUTING.md#code-style) of this project.
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-dashboard/blob/master/changelog.txt).
