### PR TITLE
Require Python 3.8+, update CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,16 +35,15 @@ jobs:
             . venv/bin/activate
             ${PYTHON} -m pip install --progress-bar off -U pip>=20.3
             ${PYTHON} -m pip install --progress-bar off -U codecov
-            ${PYTHON} -m pip install --progress-bar off -r requirements.txt
-            ${PYTHON} -m pip install --progress-bar off -r requirements-test.txt
-            ${PYTHON} -m pip install --progress-bar off .
+            ${PYTHON} -m pip install --progress-bar off -U -r requirements-test.txt
+            ${PYTHON} -m pip install --progress-bar off -e .
 
       - run:
           name: Run tests
           command: |
             . venv/bin/activate
             ${PYTHON} -m pytest --cov=signac_dashboard --cov-config=setup.cfg --cov-report=xml tests/ -v
-            codecov
+            ${PYTHON} -m codecov
 
       - store_artifacts:
           path: test-reports
@@ -60,11 +59,6 @@ jobs:
     docker:
       - image: cimg/python:3.8
 
-  linux-python-37:
-    <<: *linux-template
-    docker:
-      - image: cimg/python:3.7
-
   linux-pypy-3:
     <<: *linux-template
     docker:
@@ -72,8 +66,12 @@ jobs:
     environment:
       PYTHON: pypy3
 
-  windows-python-38:
+  windows-python-310:
     executor: win/default
+      name: win/default
+      shell: bash.exe
+    environment:
+      PYTHON: C:\Python310\python
     steps:
       - checkout
       - run:
@@ -84,20 +82,19 @@ jobs:
       - run:
           name: Install Python
           command: |
-            choco install python --version 3.8.1 --limit-output --no-progress
+            choco install python --version 3.10.2 --limit-output --no-progress
       - run:
           name: Install dependencies
           command: |
-            python --version
-            python -m pip install --progress-bar off certifi
-            python -m pip install --progress-bar off -U coverage mock
-            python -m pip install --progress-bar off -U -e .
+            ${PYTHON} -m pip install --progress-bar off -U pip>=20.3
+            ${PYTHON} -m pip install --progress-bar off -U codecov
+            ${PYTHON} -m pip install --progress-bar off -U -r requirements/requirements-test.txt
+            ${PYTHON} -m pip install --progress-bar off -U -e .
       - run:
           name: Run tests
           command: |
-            python -m coverage run --source=signac_dashboard/ -m unittest discover tests/ -v
-            python -m coverage report -i --include="signac_dashboard*"
-
+            ${PYTHON} -m pytest --cov=signac_dashboard --cov-config=setup.cfg --cov-report=xml tests/ -v
+            ${PYTHON} -m codecov
 
   test-deploy-pypi:
     docker:
@@ -139,7 +136,6 @@ workflows:
       - linux-python-310
       - linux-python-39
       - linux-python-38
-      - linux-python-37
       - linux-pypy-3
       - windows-python-38
       - test-deploy-pypi:
@@ -150,7 +146,6 @@ workflows:
             - linux-python-310
             - linux-python-39
             - linux-python-38
-            - linux-python-37
             - linux-pypy-3
             - windows-python-38
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,7 @@ workflows:
       - linux-python-39
       - linux-python-38
       - linux-pypy-3
-      - windows-python-38
+      - windows-python-310
       - test-deploy-pypi:
           filters:
             branches:
@@ -147,7 +147,7 @@ workflows:
             - linux-python-39
             - linux-python-38
             - linux-pypy-3
-            - windows-python-38
+            - windows-python-310
   deploy:
     jobs:
       - deploy-pypi:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
       PYTHON: pypy3
 
   windows-python-310:
-    executor: win/default
+    executor:
       name: win/default
       shell: bash.exe
     environment:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,31 +1,19 @@
-<!-- Provide a general summary of your changes in the Title above -->
+<!-- Provide a general summary of your changes in the title above. -->
 
 ## Description
-<!-- Describe your changes in detail -->
+<!-- Describe your changes in detail. -->
+<!-- Please indicate if the changes may break existing functionality. -->
 
 ## Motivation and Context
 <!-- Why is this change required? What problem does it solve? -->
 <!-- If it fixes an open issue, please link to the issue here. -->
 
-## Types of Changes
-<!-- Please select all items that apply either now or after creating the pull request: -->
-- [ ] Documentation update
-- [ ] Bug fix
-- [ ] New feature
-- [ ] Breaking change<sup>1</sup>
-
-<sup>1</sup>The change breaks (or has the potential to break) existing functionality.
 
 ## Checklist:
-<!-- Please select all items that apply either now or after creating the pull request. -->
+<!-- This checklist must be complete before merging the pull request. -->
 <!-- If you are unsure about any of these items, do not hesitate to ask! -->
-- [ ] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-dashboard/blob/master/CONTRIBUTING.md).
-- [ ] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-dashboard/blob/master/ContributorAgreement.md).
-- [ ] My name is on the [list of contributors](https://github.com/glotzerlab/signac-dashboard/blob/master/contributors.txt).
-- [ ] My code follows the [code style guideline](https://github.com/glotzerlab/signac-dashboard/blob/master/CONTRIBUTING.md#code-style) of this project.
+- [ ] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-dashboard/blob/master/CONTRIBUTING.md).
+- [ ] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-dashboard/blob/master/ContributorAgreement.md).
 - [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.
-
-If necessary:
-- [ ] I have updated the API documentation as part of the package doc-strings.
-- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
-- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-dashboard/blob/master/changelog.txt).
+- [ ] The [package documentation](https://github.com/glotzerlab/signac-dashboard/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
+- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-dashboard/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,17 +13,17 @@ repos:
         exclude: 'setup.cfg'
       - id: debug-statements
   - repo: https://github.com/asottile/pyupgrade
-    rev: 'v2.31.0'
+    rev: 'v2.31.1'
     hooks:
       - id: pyupgrade
         args:
-          - --py36-plus
+          - --py38-plus
   - repo: https://github.com/PyCQA/isort
     rev: '5.10.1'
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: '21.12b0'
+    rev: '22.1.0'
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/flake8

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The **signac-dashboard** package allows users to rapidly visualize and analyze d
 ## Installation
 
 The recommended installation method for **signac-dashboard** is through **conda** or **pip**.
-The software is tested for Python 3.7+ and is built for all major platforms.
+The software is tested for Python 3.8+ and is built for all major platforms.
 
 To install **signac-dashboard** *via* the [conda-forge](https://conda-forge.github.io/) channel, execute:
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,11 @@ Added
 
 - Ability to select modules and views on narrow screens (#114)
 
+Removed
++++++++
+
+- Dropped support for Python 3.7 following the recommended support schedules of `NEP 29 <https://numpy.org/neps/nep-0029-deprecation_policy.html>`__.
+
 [0.2.9] -- 2022-02-08
 ---------------------
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -5,8 +5,8 @@ Installation
 ============
 
 The recommended installation method for **signac-dashboard** is via conda_ or pip_.
-The software is tested for Python versions 3.7+. Its primary dependencies are signac_ and flask_.
-Supported Python and NumPy versions are determined according to the `NEP 29 deprecation policy <https://numpy.org/neps/nep-0029-deprecation_policy.html>`_.
+The software is tested for Python versions 3.8+. Its primary dependencies are signac_ and flask_.
+The signac framework uses the `NEP 29 deprecation policy <https://numpy.org/neps/nep-0029-deprecation_policy.html>`__ as a guideline for when to drop support for Python and NumPy versions, and does not guarantee support beyond the versions recommended in that proposal.
 
 .. _conda: https://docs.conda.io/
 .. _conda-forge: https://conda-forge.org/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-target-version = ['py36']
+target-version = ['py38']
 include = '\.pyi?$'
 exclude = '''
 (

--- a/setup.py
+++ b/setup.py
@@ -34,12 +34,13 @@ setup(
     version="0.2.9",
     packages=find_packages(),
     include_package_data=True,
-    python_requires=">=3.7,<4",
+    # Supported versions are determined according to NEP 29.
+    # https://numpy.org/neps/nep-0029-deprecation_policy.html
+    python_requires=">=3.8,<4",
     install_requires=requirements,
     classifiers=[
         "Development Status :: 3 - Alpha",
         "License :: OSI Approved :: BSD License",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/signac_dashboard/dashboard.py
+++ b/signac_dashboard/dashboard.py
@@ -219,12 +219,12 @@ class Dashboard:
                     port += 1
                 pass
 
-    @lru_cache()
+    @lru_cache
     def _schema_variables(self):
         schema = self.project.detect_schema(exclude_const=True)
         return [key for key in schema]
 
-    @lru_cache()
+    @lru_cache
     def _project_min_len_unique_id(self):
         return self.project.min_len_unique_id()
 
@@ -295,7 +295,7 @@ class Dashboard:
         key = natsort.natsort_keygen(key=self.job_title, alg=natsort.REAL)
         return key(job)
 
-    @lru_cache()
+    @lru_cache
     def _get_all_jobs(self):
         return sorted(self.project.find_jobs(), key=self.job_sorter)
 


### PR DESCRIPTION
## Description
NEP 29 has dropped support for Python < 3.8. This PR updates signac-dashboard to require Python 3.8+.

See also related changes in https://github.com/glotzerlab/signac/pull/715

## Checklist:
- [x] I am familiar with the [**Contributing Guidelines**](https://github.com/glotzerlab/signac-dashboard/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Contributor Agreement**](https://github.com/glotzerlab/signac-dashboard/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/signac-dashboard/blob/master/contributors.txt).
- [x] My code follows the [code style guideline](https://github.com/glotzerlab/signac-dashboard/blob/master/CONTRIBUTING.md#code-style) of this project.
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.

If necessary:
- [ ] I have updated the API documentation as part of the package doc-strings.
- [ ] I have created a separate pull request to update the [framework documentation](https://docs.signac.io/) on [signac-docs](https://github.com/glotzerlab/signac-docs) and linked it here.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-dashboard/blob/master/changelog.txt).
