### PR TITLE
Fix prefix_jobid issue

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,10 +10,20 @@ Version 0.2
 [0.2.11] -- 2022-xx-xx
 ----------------------
 
+Added
++++++
+
+- The endpoint ``views.get_file`` now reads the ``download_name`` request argument (#127).
+
 Changed
 +++++++
 
-- ``Dashboard.add_url`` now only accepts one rule.
+- ``Dashboard.add_url`` now only accepts one rule (#129).
+
+Fixed
++++++
+
+- FileList module now respects prefix_jobid option. (#127, #128)
 
 [0.2.10] -- 2022-04-05
 ----------------------

--- a/changelog.txt
+++ b/changelog.txt
@@ -23,7 +23,7 @@ Changed
 Fixed
 +++++
 
-- FileList module now respects prefix_jobid option. (#127, #128)
+- FileList module now respects prefix_jobid option (#127, #128).
 
 [0.2.10] -- 2022-04-05
 ----------------------

--- a/signac_dashboard/templates/cards/file_list.html
+++ b/signac_dashboard/templates/cards/file_list.html
@@ -1,5 +1,5 @@
 <ul>
   {% for file in files %}
-  <li><a href="{{ url_for('get_file', jobid=file.jobid, filename=file.name) }}" download="{{ file.download }}">{{ file.name }}</a></li>
+  <li><a href="{{ url_for('get_file', jobid=file.jobid, filename=file.name, download_name=file.download) }}" download="{{ file.download }}">{{ file.name }}</a></li>
   {% endfor %}
 </ul>

--- a/signac_dashboard/views.py
+++ b/signac_dashboard/views.py
@@ -65,7 +65,9 @@ def show_job(dashboard, jobid):
         return dashboard._render_job_view(default_view="grid")
 
 
-def get_file(dashboard, jobid, filename): # not sure if *args, **kwargs needed in argument list
+def get_file(
+    dashboard, jobid, filename
+):  # not sure if *args, **kwargs needed in argument list
     try:
         job = dashboard.project.open_job(id=jobid)
     except KeyError:
@@ -86,7 +88,7 @@ def get_file(dashboard, jobid, filename): # not sure if *args, **kwargs needed i
                 mimetype=mimetype,
                 cache_timeout=cache_timeout,
                 conditional=True,
-                download_name=download_name
+                download_name=download_name,
             )
         else:
             abort(404, "The file requested does not exist.")

--- a/signac_dashboard/views.py
+++ b/signac_dashboard/views.py
@@ -65,7 +65,7 @@ def show_job(dashboard, jobid):
         return dashboard._render_job_view(default_view="grid")
 
 
-def get_file(dashboard, jobid, filename):
+def get_file(dashboard, jobid, filename): # not sure if *args, **kwargs needed in argument list
     try:
         job = dashboard.project.open_job(id=jobid)
     except KeyError:
@@ -79,14 +79,14 @@ def get_file(dashboard, jobid, filename):
             for regex in textfile_regexes:
                 if re.match(regex, filename) is not None:
                     mimetype = "text/plain"
+            download_name = request.args.get("download_name", filename)
             return send_from_directory(
                 job.workspace(),
-                filename,
+                path=filename,
                 mimetype=mimetype,
                 cache_timeout=cache_timeout,
                 conditional=True,
-                as_attachment=True,
-                download_name="35478bb1cef990f56fd7a37abe2f88a5_energy-plot-timesteps.txt",
+                download_name=download_name
             )
         else:
             abort(404, "The file requested does not exist.")

--- a/signac_dashboard/views.py
+++ b/signac_dashboard/views.py
@@ -86,7 +86,7 @@ def get_file(dashboard, jobid, filename):
                 cache_timeout=cache_timeout,
                 conditional=True,
                 as_attachment=True,
-                download_name='35478bb1cef990f56fd7a37abe2f88a5_energy-plot-timesteps.txt',
+                download_name="35478bb1cef990f56fd7a37abe2f88a5_energy-plot-timesteps.txt",
             )
         else:
             abort(404, "The file requested does not exist.")

--- a/signac_dashboard/views.py
+++ b/signac_dashboard/views.py
@@ -81,7 +81,7 @@ def get_file(dashboard, jobid, filename):
                     mimetype = "text/plain"
             download_name = request.args.get("download_name", filename)
             return send_from_directory(
-                job.workspace(),
+                directory=job.workspace(),
                 path=filename,
                 mimetype=mimetype,
                 cache_timeout=cache_timeout,

--- a/signac_dashboard/views.py
+++ b/signac_dashboard/views.py
@@ -85,6 +85,8 @@ def get_file(dashboard, jobid, filename):
                 mimetype=mimetype,
                 cache_timeout=cache_timeout,
                 conditional=True,
+                as_attachment=True,
+                download_name='35478bb1cef990f56fd7a37abe2f88a5_energy-plot-timesteps.txt',
             )
         else:
             abort(404, "The file requested does not exist.")

--- a/signac_dashboard/views.py
+++ b/signac_dashboard/views.py
@@ -65,9 +65,7 @@ def show_job(dashboard, jobid):
         return dashboard._render_job_view(default_view="grid")
 
 
-def get_file(
-    dashboard, jobid, filename
-):  # not sure if *args, **kwargs needed in argument list
+def get_file(dashboard, jobid, filename):
     try:
         job = dashboard.project.open_job(id=jobid)
     except KeyError:


### PR DESCRIPTION
## Description
See #127. After a lot of testing, I have found that the only way to get the desired behavior for the default download name is to add `as_attachement` and `download_name` to where we call `flask.send_from_directory()` in `views.get_file()`. This initial change is obviously a bad solution: I'm hard-coding the filename. Some observed behavior:
- If I set `as_attachment=True` and do not send anything in `download_name`, I still do not get the correct default download file name in my Save As dialog box. The only thing this seems to change is the `Content-Disposition` response header, which changes from `inline; filename=filename.txt` when `as_attachment=False` to `attachment; filename=energy-plot-timesteps.txt` when `as_attachment=True`
- If I set `as_attachment=True` and set an undefined variable as `download_name` (e.g., `download_name=x`), the correct filename shows up on the download box, but a `TypeError` is thrown and the download errors out
- If I set `as_attachment=True` and pass any string into `download_name`, the dowloaded file's name is that string by default

## Motivation and Context
Resolves #127 

I do not know how to proceed. I cannot figure out how to get the correct download name into that function. Any pointers would be greatly appreciated.

## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-dashboard/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-dashboard/blob/master/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac-dashboard/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-dashboard/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
