### PR TITLE
Permit one rule per call to add_url.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,14 @@ The **signac-dashboard** package follows `semantic versioning <https://semver.or
 Version 0.2
 ===========
 
+[0.2.11] -- 2022-xx-xx
+----------------------
+
+Changed
++++++++
+
+- ``Dashboard.add_url`` now only accepts one rule.
+
 [0.2.10] -- 2022-04-05
 ----------------------
 

--- a/signac_dashboard/dashboard.py
+++ b/signac_dashboard/dashboard.py
@@ -401,7 +401,12 @@ class Dashboard:
         return [self._job_details(job) for job in list(jobs)]
 
     def add_url(
-        self, import_name, url_rules=[], import_file="signac_dashboard", **options
+        self,
+        import_name,
+        url_rule,
+        endpoint=None,
+        import_file="signac_dashboard",
+        **kwargs,
     ):
         """Add a route to the dashboard.
 
@@ -437,23 +442,25 @@ class Dashboard:
 
         :param import_name: The view function name to be imported.
         :type import_name: str
-        :param url_rules: A list of URL rules, see
-            :py:meth:`flask.Flask.add_url_rule`.
-        :type url_rules: list
+        :param url_rule: URL rule, see :py:meth:`flask.Flask.add_url_rule`.
+        :type url_rule: str
+        :param endpoint: The endpoint name. Must be unique. If None, defaults
+            to the name of the view function (default: None).
+        :type endpoint: str
         :param import_file: The module from which to import (default:
             :code:`'signac_dashboard'`).
         :type import_file: str
-        :param \\**options: Additional options to pass to
+        :param \\**kwargs: Additional keyword arguments to pass to
             :py:meth:`flask.Flask.add_url_rule`.
         """
         if import_file is not None:
             import_name = import_file + "." + import_name
-        for url_rule in url_rules:
-            self.app.add_url_rule(
-                rule=url_rule,
-                view_func=LazyView(dashboard=self, import_name=import_name),
-                **options,
-            )
+        self.app.add_url_rule(
+            rule=url_rule,
+            endpoint=endpoint,
+            view_func=LazyView(dashboard=self, import_name=import_name),
+            **kwargs,
+        )
 
     def _register_routes(self):
         """Registers routes with the Flask application.
@@ -508,13 +515,13 @@ class Dashboard:
         def favicon():
             return url_for("static", filename="favicon.ico")
 
-        self.add_url("views.home", ["/"])
-        self.add_url("views.settings", ["/settings"])
-        self.add_url("views.search", ["/search"])
-        self.add_url("views.jobs_list", ["/jobs/"])
-        self.add_url("views.show_job", ["/jobs/<jobid>"])
-        self.add_url("views.get_file", ["/jobs/<jobid>/file/<path:filename>"])
-        self.add_url("views.change_modules", ["/modules"], methods=["POST"])
+        self.add_url("views.home", "/")
+        self.add_url("views.settings", "/settings")
+        self.add_url("views.search", "/search")
+        self.add_url("views.jobs_list", "/jobs/")
+        self.add_url("views.show_job", "/jobs/<jobid>")
+        self.add_url("views.get_file", "/jobs/<jobid>/file/<path:filename>")
+        self.add_url("views.change_modules", "/modules", methods=["POST"])
 
     def update_cache(self):
         """Clear project and dashboard server caches.


### PR DESCRIPTION
## Description
This PR rewrites `Dashboard.add_url` to accept only one rule, and allows overriding the endpoint name if the same view function needs to be reused.

While reading over #128, I noticed a flaw in the `add_url` function. It accepts multiple rules, but if multiple rules are supplied, the endpoints are the same for each rule which results in a error being raised:
```
AssertionError: View function mapping is overwriting an existing endpoint function: get_file
```

## Checklist:
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-dashboard/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-dashboard/blob/master/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac-dashboard/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-dashboard/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.