### PR TITLE
Add option for CARDS_PER_ROW.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@ Added
 - The Project page displays cards from modules with ``context="ProjectContext"`` (#27, #110).
 - Schema module for the ProjectContext (#110).
 - ProjectContext support for the DocumentList, ImageViewer, TextDisplay, and VideoViewer modules (#110).
+- Dashboard config option ``CARDS_PER_ROW`` controls the number of cards per row in the desktop view (#133).
 
 Changed
 +++++++

--- a/examples/kitchen-sink/dashboard.py
+++ b/examples/kitchen-sink/dashboard.py
@@ -21,9 +21,13 @@ if __name__ == "__main__":
             for b in range(10):
                 project.open_job({"a": a, "b": b}).init()
 
+    config = {
+        "CARDS_PER_ROW": 4,
+    }
+
     modules = []
     if "dashboard" not in project.document:
         # Initialize a new Dashboard using all modules with default settings
         for m in signac_dashboard.modules.__all__:
             modules.append(getattr(signac_dashboard.modules, m).__call__())
-    Dashboard(modules=modules, project=Project.get_project()).main()
+    Dashboard(config=config, modules=modules, project=Project.get_project()).main()

--- a/signac_dashboard/dashboard.py
+++ b/signac_dashboard/dashboard.py
@@ -132,7 +132,7 @@ class Dashboard:
         grouped = groupby(sorted(self.modules, key=keyfunc), key=keyfunc)
         modules_by_context = {}
         for context_key, context_group in grouped:
-            modules_by_context[context_key] = [m for m in context_group if m.enabled]
+            modules_by_context[context_key] = [m for m in context_group]
         self._modules_by_context = modules_by_context
 
     def _create_app(self, config={}):

--- a/signac_dashboard/dashboard.py
+++ b/signac_dashboard/dashboard.py
@@ -61,6 +61,8 @@ class Dashboard:
       :code:`True` (default: :code:`False`).
     - **PER_PAGE**: Maximum number of jobs to show per page
       (default: 25).
+    - **CARDS_PER_ROW**: Cards to show per row in the desktop view. Must be a
+      factor of 12 (default: 3).
     - **SECRET_KEY**: This must be specified to run via WSGI with multiple
       workers, so that sessions remain intact. See the
       `Flask docs <http://flask.pocoo.org/docs/1.0/config/#SECRET_KEY>`_
@@ -93,9 +95,15 @@ class Dashboard:
 
         # Prepare this dashboard instance to run.
 
-        # Set configuration defaults and save to the project document
+        # Set configuration defaults
         self.config.setdefault("PAGINATION", True)
         self.config.setdefault("PER_PAGE", 25)
+        self.config.setdefault("CARDS_PER_ROW", 3)
+        if 12 % self.config["CARDS_PER_ROW"] != 0:
+            raise ValueError(
+                "The value of CARDS_PER_ROW must be a factor of 12. Got "
+                f"{self.config['CARDS_PER_ROW']}."
+            )
 
         # Create and configure the Flask application
         self.app = self._create_app(self.config)
@@ -515,6 +523,7 @@ class Dashboard:
                 "APP_VERSION": __version__,
                 "PROJECT_NAME": self.project.config["project"],
                 "PROJECT_DIR": self.project.config["project_dir"],
+                "CARDS_PER_ROW": self.config["CARDS_PER_ROW"],
                 "modules": self.modules,
                 "modules_by_context": self._modules_by_context,
                 "enabled_module_indices": session["enabled_module_indices"],

--- a/signac_dashboard/templates/jobs_grid.html
+++ b/signac_dashboard/templates/jobs_grid.html
@@ -13,6 +13,7 @@
 
 {% set context = "JobContext" %}
 {% set num_enabled_modules = enabled_module_indices[context] | length %}
+{% set columns_per_card = (12 / CARDS_PER_ROW) | int %}
 
 
 {% block panels %}
@@ -37,7 +38,7 @@
     {% for card in module.get_cards(job_details.job) %} {# begin cards #}
         {# jinja variables go out of scope after the loop unless this "list" hack is used #}
         {% if card_count.append(1) %}{% endif %}
-        <div class="column is-4-desktop is-full-mobile">
+        <div class="column is-{{ columns_per_card }}-desktop is-full-mobile">
             <div class="card">
                 <div class="card-header">
                     <div class="card-header-title card-header-dashboard">
@@ -57,7 +58,7 @@
     {% endif %} {# end if module is enabled #}
     {% endfor %} {# end modules #}
     {% if card_count | length == 0 and num_enabled_modules > 1 %} {# begin no cards message #}
-        <div class="column is-4-desktop is-full-mobile">
+        <div class="column is-{{ columns_per_card }}-desktop is-full-mobile">
             <h6 class="subtitle is-6">No cards to show.</h6>
         </div>
     {% endif %} {# end no cards message #}

--- a/signac_dashboard/templates/project_info.html
+++ b/signac_dashboard/templates/project_info.html
@@ -7,6 +7,7 @@
 
 {% set context = "ProjectContext" %}
 {% set num_enabled_modules = enabled_module_indices[context] | length %}
+{% set columns_per_card = (12 / CARDS_PER_ROW) | int %}
 
 {% set card_count = [] %}
 {% if num_enabled_modules > 1 %}
@@ -17,7 +18,7 @@
     {% for card in module.get_cards(g.project) %} {# begin cards #}
         {# jinja variables go out of scope after the loop unless this "list" hack is used #}
         {% if card_count.append(1) %}{% endif %}
-        <div class="column is-4-desktop is-full-mobile">
+        <div class="column is-{{ columns_per_card }}-desktop is-full-mobile">
             <div class="card">
                 <div class="card-header">
                     <div class="card-header-title card-header-dashboard">


### PR DESCRIPTION
## Description
This adds a config option for the number of cards per row. The default value is 3.

## Motivation and Context
I have often wanted to set this to 4 cards per row instead, to make better use of screen space on large monitors.

Tested manually with a few example projects. It also works in compact mode (when only one module is enabled).

## Checklist:
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-dashboard/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-dashboard/blob/master/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac-dashboard/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-dashboard/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.