### PR TITLE
Fix bug where disabled modules don't appear in the module list.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -26,6 +26,7 @@ Fixed
 +++++
 
 - Hide the list and grid view buttons when viewing a single job (#92, #110).
+- Fixed bug with disabled modules not showing a checkbox to enable them in the grid view (#134).
 
 Version 0.2
 ===========

--- a/signac_dashboard/dashboard.py
+++ b/signac_dashboard/dashboard.py
@@ -124,7 +124,7 @@ class Dashboard:
         grouped = groupby(sorted(self.modules, key=keyfunc), key=keyfunc)
         modules_by_context = {}
         for context_key, context_group in grouped:
-            modules_by_context[context_key] = [m for m in context_group if m.enabled]
+            modules_by_context[context_key] = [m for m in context_group]
         self._modules_by_context = modules_by_context
 
     def _create_app(self, config={}):


### PR DESCRIPTION
## Description
This fixes a bug from #110 where disabled modules weren't showing up in the module list.

## Context
The "disabled" state means that a module is unchecked in the grid view at launch. The module should still have a checkbox that allows users to enable it for their browser session.

Tested manually on two different dashboard projects.

## Checklist:
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-dashboard/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-dashboard/blob/master/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac-dashboard/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-dashboard/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.