### PR TITLE
Release/0.3.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,7 +7,7 @@ The **signac-dashboard** package follows `semantic versioning <https://semver.or
 Version 0.3
 ===========
 
-[0.3.0] -- 2022-xx-xx
+[0.3.0] -- 2022-06-22
 ---------------------
 
 Added
@@ -46,7 +46,7 @@ Version 0.2
 Added
 +++++
 
-- Ability to select modules and views on narrow screens (#114).
+- Ability to select modules and views on narrow screens (#93, #114).
 
 Fixed
 +++++

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -23,9 +23,9 @@ copyright = "The Regents of the University of Michigan"
 author = "Bradley D. Dice, Carl S. Adorf, Sharon C. Glotzer"
 
 # The short X.Y version
-version = "0.2.10"
+version = "0.3.0"
 # The full version, including alpha/beta/rc tags
-release = "0.2.10"
+release = "0.3.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.10
+current_version = 0.3.0
 commit = True
 tag = True
 message = Bump up to version {new_version}.
@@ -25,3 +25,4 @@ ignore = E123,E126,E203,E226,E241,E704,W503,W504
 filterwarnings = 
 	ignore:.*SimpleKeyring is deprecated.*:DeprecationWarning
 	ignore:.*The doc_filter argument was deprecated.*:DeprecationWarning
+

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ except OSError:
 
 setup(
     name="signac-dashboard",
-    version="0.2.10",
+    version="0.3.0",
     packages=find_packages(),
     include_package_data=True,
     # Supported versions are determined according to NEP 29.

--- a/signac_dashboard/version.py
+++ b/signac_dashboard/version.py
@@ -2,4 +2,4 @@
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
 
-__version__ = "0.2.10"
+__version__ = "0.3.0"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Description
<!-- Describe your changes in detail. -->
<!-- Please indicate if the changes may break existing functionality. -->

This release adds a project overview page and the modules for it. We welcome new contributor @Charlottez112!

# Added

- The Project page displays cards from modules with ``context="ProjectContext"`` (#27, #110).
- Schema module for the ProjectContext (#110).
- ProjectContext support for the DocumentList, ImageViewer, TextDisplay, and VideoViewer modules (#110).
- Dashboard config option ``CARDS_PER_ROW`` controls the number of cards per row in the desktop view (#133).
- The endpoint ``views.get_file`` now reads the ``download_name`` request argument (#127).

# Changed

- Hide the list of modules in the sidebar when viewing the job list (#110).

# Fixed

- Hide the list and grid view buttons when viewing a single job (#92, #110).
- Fixed bug with disabled modules not showing a checkbox to enable them in the grid view (#134).
- FileList module now respects prefix_jobid option (#127, #128).
- Endpoints added via ``Dashboard.add_url`` can be used with multiple routes (#130).

# Removed

- Removed upper bound on ``python_requires`` (#137).
