### PR TITLE
Fix to allow running in debug mode

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -26,6 +26,9 @@ Fixed
 
 - Fixed handling of ``--debug`` command line option (#152).
 
+Version 0.3
+===========
+
 [0.3.1] -- 2022-10-17
 ---------------------
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,13 @@ The **signac-dashboard** package follows `semantic versioning <https://semver.or
 Version 0.3
 ===========
 
+[0.3.2] -- 2022-xx-xx
+
+Fixed
++++++
+
+- Fixed handling of --debug command line option (#152).
+
 [0.3.1] -- 2022-10-17
 
 Changed

--- a/changelog.txt
+++ b/changelog.txt
@@ -21,15 +21,10 @@ Changed
 
 - ``ImageViewer`` searches for ``*.svg`` files by default.
 
-Version 0.3
-===========
-
-[0.3.2] -- 2022-xx-xx
-
 Fixed
 +++++
 
-- Fixed handling of --debug command line option (#152).
+- Fixed handling of ``--debug`` command line option (#152).
 
 [0.3.1] -- 2022-10-17
 ---------------------

--- a/signac_dashboard/dashboard.py
+++ b/signac_dashboard/dashboard.py
@@ -649,7 +649,7 @@ class Dashboard:
         """Call the dashboard as a WSGI application."""
         return self.app(environ, start_response)
 
-    def main(self, *command_args):
+    def main(self, command_args=None):
         """Runs the command line interface.
 
         Call this function to use signac-dashboard from its command line
@@ -670,9 +670,13 @@ class Dashboard:
         .. code-block:: bash
 
             python dashboard.py run
+
+        :param command_args: List of CLI arguments to pass, e.g.
+            ``["--debug", "--port", "8889"]`` (default: None).
+        :type command_args: list
         """
 
-        if len(command_args) == 0:
+        if command_args is not None and len(command_args) == 0:
             command_args = None
 
         def _run(args):
@@ -734,7 +738,7 @@ class Dashboard:
             print("signac-dashboard", __version__)
             sys.exit(0)
 
-        args = parser.parse_args(command_args[0])
+        args = parser.parse_args(command_args)
 
         if args.debug:
             logger.setLevel(logging.DEBUG)

--- a/signac_dashboard/dashboard.py
+++ b/signac_dashboard/dashboard.py
@@ -223,11 +223,12 @@ class Dashboard:
         """
         host = self.config.get("HOST", "localhost")
         port = self.config.get("PORT", 8888)
+        debug = self.config.get("DEBUG", False)
         max_retries = 5
 
         for _ in range(max_retries):
             try:
-                self.app.run(host, port, *args, **kwargs)
+                self.app.run(host=host, port=port, debug=debug, *args, **kwargs)
                 break
             except OSError as e:
                 logger.warning(e)

--- a/signac_dashboard/dashboard.py
+++ b/signac_dashboard/dashboard.py
@@ -591,7 +591,7 @@ class Dashboard:
         """Call the dashboard as a WSGI application."""
         return self.app(environ, start_response)
 
-    def main(self):
+    def main(self, test_args=None):
         """Runs the command line interface.
 
         Call this function to use signac-dashboard from its command line
@@ -665,7 +665,7 @@ class Dashboard:
             print("signac-dashboard", __version__)
             sys.exit(0)
 
-        args = parser.parse_args()
+        args = parser.parse_args(test_args)
 
         if args.debug:
             logger.setLevel(logging.DEBUG)

--- a/signac_dashboard/dashboard.py
+++ b/signac_dashboard/dashboard.py
@@ -649,7 +649,7 @@ class Dashboard:
         """Call the dashboard as a WSGI application."""
         return self.app(environ, start_response)
 
-    def main(self, test_args=None):
+    def main(self, *command_args):
         """Runs the command line interface.
 
         Call this function to use signac-dashboard from its command line
@@ -671,6 +671,9 @@ class Dashboard:
 
             python dashboard.py run
         """
+
+        if len(command_args) == 0:
+            command_args = None
 
         def _run(args):
             kwargs = vars(args)
@@ -731,7 +734,7 @@ class Dashboard:
             print("signac-dashboard", __version__)
             sys.exit(0)
 
-        args = parser.parse_args(test_args)
+        args = parser.parse_args(command_args[0])
 
         if args.debug:
             logger.setLevel(logging.DEBUG)

--- a/signac_dashboard/dashboard.py
+++ b/signac_dashboard/dashboard.py
@@ -228,7 +228,7 @@ class Dashboard:
 
         for _ in range(max_retries):
             try:
-                self.app.run(host=host, port=port, debug=debug, *args, **kwargs)
+                self.app.run(host, port, debug, *args, **kwargs)
                 break
             except OSError as e:
                 logger.warning(e)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -182,13 +182,13 @@ class TestCommandLine(unittest.TestCase):
     def setUp(self):
         self._tmp_dir = tempfile.mkdtemp()
         self.project = init_project(root=self._tmp_dir, make_dir=False)
-        self.config={}
-        self.modules=[]
+        self.config = {}
+        self.modules = []
         self.dashboard = Dashboard(self.config, self.project, self.modules)
         self.test_client = self.dashboard.app.test_client()
 
     def test_debug_mode(self):
-        self.dashboard.main(['run', '--debug', '--port', '8765'])
+        self.dashboard.main(["run", "--debug", "--port", "8765"])
         assert self.dashboard.config.get("DEBUG")
 
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -178,5 +178,19 @@ class AllModulesTestCase(DashboardTestCase):
         assert "No modules for the JobContext are enabled." not in job_response
 
 
+class TestCommandLine(unittest.TestCase):
+    def setUp(self):
+        self._tmp_dir = tempfile.mkdtemp()
+        self.project = init_project(root=self._tmp_dir, make_dir=False)
+        self.config={}
+        self.modules=[]
+        self.dashboard = Dashboard(self.config, self.project, self.modules)
+        self.test_client = self.dashboard.app.test_client()
+
+    def test_debug_mode(self):
+        self.dashboard.main(['run', '--debug', '--port', '8765'])
+        assert self.dashboard.config.get("DEBUG")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -196,19 +196,5 @@ class AllModulesTestCase(DashboardTestCase):
         assert "No modules for the JobContext are enabled." not in job_response
 
 
-class TestCommandLine(unittest.TestCase):
-    def setUp(self):
-        self._tmp_dir = tempfile.mkdtemp()
-        self.project = init_project(root=self._tmp_dir, make_dir=False)
-        self.config = {}
-        self.modules = []
-        self.dashboard = Dashboard(self.config, self.project, self.modules)
-        self.test_client = self.dashboard.app.test_client()
-
-    def test_debug_mode(self):
-        self.dashboard.main(["run", "--debug", "--port", "8765"])
-        assert self.dashboard.config.get("DEBUG")
-
-
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Description
<!-- Describe your changes in detail. -->
<!-- Please indicate if the changes may break existing functionality. -->

Correctly handle passing config arguments to the [run function of Flask](https://flask.palletsprojects.com/en/2.2.x/debugging/).

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Running with
```
python dashboard.py run --debug
```
did not actually enable debug mode as indicated by the status printout
```
 * Serving Flask app 'signac-dashboard'
 * Debug mode: off
```

I also added keyword arguments to make it easier to follow.


## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-dashboard/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-dashboard/blob/master/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac-dashboard/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-dashboard/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
