### PR TITLE
Display job names when one module is enabled

### DIFF
--- a/signac_dashboard/templates/jobs_grid.html
+++ b/signac_dashboard/templates/jobs_grid.html
@@ -17,20 +17,20 @@
 
 
 {% block panels %}
-{% if num_enabled_modules <= 1 %}
+{% if num_enabled_modules < 1 %}
 <section class="section panel">
     <div class="columns is-mobile is-multiline">
 {% endif %}
 {% for job_details in g.jobs %}
 {% set card_count = [] %}
-{% if num_enabled_modules > 1 %}
+{% if num_enabled_modules >= 1 %}
 <section class="section panel" id="{{ job_details.job._id }}">
 {% endif %}
-    {% if ( num_enabled_modules > 1 and g.jobs | length > 1 ) or ( g.jobs | length == 1 and query is defined ) %}
+    {% if ( num_enabled_modules >= 1 and g.jobs | length >= 1 ) or ( g.jobs | length < 1 and query is defined ) %}
     <h4 class="title is-4">{{ job_details.title }}</h4>
     <h5 class="subtitle is-5"><a href="{{ url_for('show_job', jobid=job_details.job._id) }}">{{ job_details.job | string }}</a></h5>
     {% endif %}
-    {% if num_enabled_modules > 1 %}
+    {% if num_enabled_modules >= 1 %}
     <div class="columns is-mobile is-multiline">
     {% endif %}
     {% for module in modules_by_context[context] %} {# begin modules #}
@@ -42,7 +42,7 @@
             <div class="card">
                 <div class="card-header">
                     <div class="card-header-title card-header-dashboard">
-                        {% if num_enabled_modules <= 1 and g.jobs | length > 1 %}
+                        {% if num_enabled_modules < 1 and g.jobs | length >= 1 %}
                         <h5 class="title is-5">{{ job_details.title }}</h5>
                         <h6 class="subtitle is-6"><a href="{{ url_for('show_job', jobid=job_details.job._id) }}">{{ job_details.job | string }}</a></h6>
                         {% endif %}
@@ -57,12 +57,12 @@
     {% endfor %} {# end cards #}
     {% endif %} {# end if module is enabled #}
     {% endfor %} {# end modules #}
-    {% if card_count | length == 0 and num_enabled_modules > 1 %} {# begin no cards message #}
+    {% if card_count | length == 0 and num_enabled_modules >= 1 %} {# begin no cards message #}
         <div class="column is-{{ columns_per_card }}-desktop is-full-mobile">
             <h6 class="subtitle is-6">No cards to show.</h6>
         </div>
     {% endif %} {# end no cards message #}
-{% if num_enabled_modules > 1 %}
+{% if num_enabled_modules >= 1 %}
     </div>
 </section>
 {% if not loop.last %}
@@ -70,7 +70,7 @@
 {% endif %}
 {% endif %}
 {% endfor %} {# end jobs #}
-{% if num_enabled_modules <= 1 %}
+{% if num_enabled_modules < 1 %}
     </div>
 </section>
 {% endif %}


### PR DESCRIPTION
Currently if only one module is enabled, job names are not displayed in grid view. If multiple cards are created for one module, the cards won't be separated by job names. Instead, the name of the job will be included in the card title. See figures below:

![image](https://user-images.githubusercontent.com/56694726/197245114-331cc202-9ef8-456f-b3a9-b303755acc92.png)

With the new changes:

![image](https://user-images.githubusercontent.com/56694726/197245524-60c894fd-a40a-4c8d-a690-977842c8cb56.png)


## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-dashboard/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-dashboard/blob/master/ContributorAgreement.md).
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] The [package documentation](https://github.com/glotzerlab/signac-dashboard/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-dashboard/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
