### PR TITLE
Add .svg to the default image viewer search.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,14 @@ The **signac-dashboard** package follows `semantic versioning <https://semver.or
 Version 0.3
 ===========
 
+[next release] -- YYYY-MM-DD
+----------------------------
+
+Changed
++++++++
+
+- ``ImageViewer`` searches for ``*.svg`` files by default.
+
 [0.3.1] -- 2022-10-17
 
 Changed

--- a/changelog.txt
+++ b/changelog.txt
@@ -16,16 +16,13 @@ Added
 - Improve security on multi-user systems. Dashboard now generates a login token when started. Users
   must login with the token to view project and job data in the dashboard.
 
-Version 0.3
-===========
-
-[next release] -- YYYY-MM-DD
-----------------------------
-
 Changed
 +++++++
 
 - ``ImageViewer`` searches for ``*.svg`` files by default.
+
+Version 0.3
+===========
 
 [0.3.1] -- 2022-10-17
 ---------------------

--- a/signac_dashboard/modules/image_viewer.py
+++ b/signac_dashboard/modules/image_viewer.py
@@ -14,7 +14,7 @@ class ImageViewer(Module):
     """Displays images that match a glob.
 
     The ImageViewer module can display images in any format that works with a standard
-    ``<img>`` tag. The module defaults to showing all images of PNG, JPG, or GIF
+    ``<img>`` tag. The module defaults to showing all images of PNG, JPG, GIF, and SVG
     types in the job or project root directory. A filename or glob can be
     defined to select specific filenames. Each matching file yields a card.
 
@@ -24,7 +24,7 @@ class ImageViewer(Module):
     .. code-block:: python
 
         from signac_dashboard.modules import ImageViewer
-        img_mod = ImageViewer()  # Show all PNG/JPG/GIF images
+        img_mod = ImageViewer()  # Show all PNG/JPG/GIF/SVG images
         img_mod = ImageViewer(name='Bond Order Diagram', img_globs=['bod.png'])
         img_mod = ImageViewer(context="ProjectContext",
                               img_globs=['/gallery/*.png'])  # search subdirectory of project root

--- a/signac_dashboard/modules/image_viewer.py
+++ b/signac_dashboard/modules/image_viewer.py
@@ -33,7 +33,7 @@ class ImageViewer(Module):
     :type context: str
     :param img_globs: A list of glob expressions or exact filenames,
         relative to the job or project root directory, to be
-        displayed (default: :code:`['*.png', '*.jpg', '*.gif']`).
+        displayed (default: :code:`['*.png', '*.jpg', '*.gif', '*.svg']`).
     :type img_globs: list
 
     """
@@ -45,7 +45,7 @@ class ImageViewer(Module):
         name="Image Viewer",
         context="JobContext",
         template="cards/image_viewer.html",
-        img_globs=("*.png", "*.jpg", "*.gif"),
+        img_globs=("*.png", "*.jpg", "*.gif", "*.svg"),
         **kwargs,
     ):
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Description
<!-- Describe your changes in detail. -->
<!-- Please indicate if the changes may break existing functionality. -->
Add `"*.svg"` to the default `img_globs` list for `ImageViewer`.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
`svg` is a common image file format supported by all modern browsers. It can be natively generated by tools such as `matplotlib`. As a vector format, `svg` files are more readable than raster formats when the images contain text and line art. In most cases, `svg` files are also smaller than raster files.

## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-dashboard/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-dashboard/blob/master/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac-dashboard/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-dashboard/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
