### PR TITLE
Require login to view job and project data

### DIFF
--- a/.github/workflows/ci-oldest-reqs.txt
+++ b/.github/workflows/ci-oldest-reqs.txt
@@ -1,5 +1,6 @@
 flask==2.1.0
 flask-assets==2.0.0
+flask-login==0.6.0
 flask-turbolinks
 jinja2==3.0.0
 jsmin
@@ -12,4 +13,3 @@ signac==1.0.0
 watchdog
 webassets==2.0.0
 werkzeug==2.1.0
-flask-login==0.6.0

--- a/.github/workflows/ci-oldest-reqs.txt
+++ b/.github/workflows/ci-oldest-reqs.txt
@@ -12,3 +12,4 @@ signac==1.0.0
 watchdog
 webassets==2.0.0
 werkzeug==2.1.0
+flask-login==0.6.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,17 +4,20 @@ Changes
 
 The **signac-dashboard** package follows `semantic versioning <https://semver.org/>`_.
 
-Version 0.3
+Version 0.4
 ===========
 
 [next release] -- YYYY-MM-DD
 ----------------------------
 
-Changed
-+++++++
+Added
++++++
 
 - Improve security on multi-user systems. Dashboard now generates a login token when started. Users
   must login with the token to view project and job data in the dashboard.
+
+Version 0.3
+===========
 
 [0.3.1] -- 2022-10-17
 ---------------------

--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,15 @@ The **signac-dashboard** package follows `semantic versioning <https://semver.or
 Version 0.3
 ===========
 
+[next release] -- YYYY-MM-DD
+----------------------------
+
+Changed
++++++++
+
+- Improve security on multi-user systems. Dashboard now generates a login token when started. Users
+  must login with the token to view project and job data in the dashboard.
+
 [0.3.1] -- 2022-10-17
 
 Changed

--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@ Changed
   must login with the token to view project and job data in the dashboard.
 
 [0.3.1] -- 2022-10-17
+---------------------
 
 Changed
 +++++++

--- a/doc/security.rst
+++ b/doc/security.rst
@@ -8,3 +8,8 @@ Running the **signac-dashboard** Flask server with a configuration that makes it
 For example, user-implemented modules may not be safe-guarded against arbitrary code execution.
 To enable remote access, use :ref:`secure port forwarding via SSH<signac-docs:dashboard-remote-ssh>`.
 The use of the :code:`$where` operation in searches is disabled by default and must be :ref:`explicitly enabled<python-api-dashboard>`, in which case the dashboard is vulnerable against `code-injection attacks <https://en.wikipedia.org/wiki/Code_injection>`_.
+
+By default, **signac-dashboard** generates an access token that is required to login to the web page.
+This protects your data from access by other users on multi-user systems.
+To disable authentication, set ``ACCESS_TOKEN`` to ``None`` in the ``config`` dictionary.
+To protect your data, disable authentication only when running on a dedicated host that provides additional layers of security.

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ signac>=1.0.0
 watchdog
 webassets>=2.0.0
 werkzeug>=2.1.0
+flask-login>=0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 flask>=2.1.0
 flask-assets>=2.0.0
+flask-login>=0.6.0
 flask-turbolinks
 jinja2>=3.0.0
 jsmin
@@ -10,4 +11,3 @@ signac>=1.0.0
 watchdog
 webassets>=2.0.0
 werkzeug>=2.1.0
-flask-login>=0.6.0

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ from setuptools import find_packages, setup
 requirements = [
     "flask>=2.1.0",
     "flask-assets>=2.0.0",
+    "flask-login>=0.6.0",
     "flask-turbolinks",
     "jinja2>=3.0.0",
     "jsmin",
@@ -18,7 +19,6 @@ requirements = [
     "watchdog",
     "webassets>=2.0.0",
     "werkzeug>=2.1.0",
-    "flask-login>=0.6.0",
 ]
 
 description = "Visualize data spaces in a web browser."

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ requirements = [
     "watchdog",
     "webassets>=2.0.0",
     "werkzeug>=2.1.0",
+    "flask-login>=0.6.0",
 ]
 
 description = "Visualize data spaces in a web browser."

--- a/signac_dashboard/dashboard.py
+++ b/signac_dashboard/dashboard.py
@@ -121,9 +121,7 @@ class Dashboard:
                 f"{self.config['CARDS_PER_ROW']}."
             )
 
-        if "ACCESS_TOKEN" not in config:
-            access_token = secrets.token_urlsafe()
-            self.config["ACCESS_TOKEN"] = access_token
+        self.config.setdefault("ACCESS_TOKEN", secrets.token_urlsafe())
 
         # Create and configure the Flask application
         self.app = self._create_app(self.config)

--- a/signac_dashboard/dashboard.py
+++ b/signac_dashboard/dashboard.py
@@ -144,7 +144,6 @@ class Dashboard:
 
         @self.login_manager.request_loader
         def load_user_from_request(request):
-            print("Handling request")
             if self.config["ACCESS_TOKEN"] is None:
                 return User("None")
 

--- a/signac_dashboard/dashboard.py
+++ b/signac_dashboard/dashboard.py
@@ -679,7 +679,7 @@ class Dashboard:
             self.config["PROFILE"] = kwargs.pop("profile")
             self.config["DEBUG"] = kwargs.pop("debug")
 
-            if self.config['ACCESS_TOKEN'] is not None:
+            if self.config["ACCESS_TOKEN"] is not None:
                 print(
                     f"To access this server, connect to: "
                     f"http://{self.config['HOST']}:{self.config['PORT']}/"

--- a/signac_dashboard/dashboard.py
+++ b/signac_dashboard/dashboard.py
@@ -579,7 +579,7 @@ class Dashboard:
 
         @dashboard.login_manager.unauthorized_handler
         def unauthorized_handler():
-            return self._render_error("Unauthorized")
+            return self._render_error("Access token is required.")
 
         @dashboard.app.route("/login")
         def login():

--- a/signac_dashboard/dashboard.py
+++ b/signac_dashboard/dashboard.py
@@ -608,6 +608,7 @@ class Dashboard:
         def favicon():
             return url_for("static", filename="favicon.ico")
 
+        # These routes are protected within the LazyView utility class
         self.add_url("views.home", ["/"])
         self.add_url("views.settings", ["/settings"])
         self.add_url("views.search", ["/search"])

--- a/signac_dashboard/dashboard.py
+++ b/signac_dashboard/dashboard.py
@@ -15,11 +15,11 @@ from functools import lru_cache
 from itertools import groupby
 from numbers import Real
 
+import flask_login
 import jinja2
 import natsort
 import signac
-import flask_login
-from flask import Flask, flash, g, render_template, redirect, request, session, url_for
+from flask import Flask, flash, g, redirect, render_template, request, session, url_for
 from flask_assets import Bundle, Environment
 from flask_turbolinks import turbolinks
 from watchdog.events import FileSystemEventHandler
@@ -121,9 +121,9 @@ class Dashboard:
                 f"{self.config['CARDS_PER_ROW']}."
             )
 
-        if 'ACCESS_TOKEN' not in config:
+        if "ACCESS_TOKEN" not in config:
             access_token = secrets.token_urlsafe()
-            self.config['ACCESS_TOKEN'] = access_token
+            self.config["ACCESS_TOKEN"] = access_token
 
         # Create and configure the Flask application
         self.app = self._create_app(self.config)
@@ -134,7 +134,7 @@ class Dashboard:
 
         @self.login_manager.user_loader
         def user_loader(identifier):
-            if secrets.compare_digest(identifier, self.config['ACCESS_TOKEN']):
+            if secrets.compare_digest(identifier, self.config["ACCESS_TOKEN"]):
                 return User(identifier)
 
             return None
@@ -581,17 +581,17 @@ class Dashboard:
 
         @dashboard.login_manager.unauthorized_handler
         def unauthorized_handler():
-            return self._render_error(str('Unauthorized'))
+            return self._render_error("Unauthorized")
 
-        @dashboard.app.route('/login')
+        @dashboard.app.route("/login")
         def login():
-            provided_token = request.args.get('token')
-            if provided_token == self.config['ACCESS_TOKEN']:
+            provided_token = request.args.get("token")
+            if provided_token == self.config["ACCESS_TOKEN"]:
                 user = User(provided_token)
                 flask_login.login_user(user)
                 return redirect("/")
 
-            return self._render_error(str('Invalid token'))
+            return self._render_error("Invalid token")
 
         @dashboard.app.route("/favicon.ico")
         @flask_login.login_required
@@ -668,9 +668,11 @@ class Dashboard:
             self.config["PROFILE"] = kwargs.pop("profile")
             self.config["DEBUG"] = kwargs.pop("debug")
 
-            print(f"To access this server, connect to: "
-                  f"http://{self.config['HOST']}:{self.config['PORT']}/"
-                  f"login?token={self.config['ACCESS_TOKEN']}")
+            print(
+                f"To access this server, connect to: "
+                f"http://{self.config['HOST']}:{self.config['PORT']}/"
+                f"login?token={self.config['ACCESS_TOKEN']}"
+            )
 
             self.run()
 

--- a/signac_dashboard/dashboard.py
+++ b/signac_dashboard/dashboard.py
@@ -593,11 +593,6 @@ class Dashboard:
 
             return self._render_error(str('Invalid token'))
 
-        @dashboard.app.route('/protected')
-        @flask_login.login_required
-        def protected():
-            return 'Logged in as: ' + flask_login.current_user.id
-
         @dashboard.app.route("/favicon.ico")
         @flask_login.login_required
         def favicon():

--- a/signac_dashboard/dashboard.py
+++ b/signac_dashboard/dashboard.py
@@ -77,7 +77,7 @@ class Dashboard:
     - **CARDS_PER_ROW**: Cards to show per row in the desktop view. Must be a
       factor of 12 (default: 3).
     - **ACCESS_TOKEN**: The access token required to login to the dashboard.
-      Set to `None` to disable authentication (not recommended on multi-user
+      Set to :code:`None` to disable authentication (not recommended on multi-user
       systems).
     - **SECRET_KEY**: This must be specified to run via WSGI with multiple
       workers, so that sessions remain intact. See the

--- a/signac_dashboard/module.py
+++ b/signac_dashboard/module.py
@@ -58,6 +58,7 @@ class Module:
 
         def register(self, dashboard):
             @dashboard.app.route('/module/my-module/update', methods=['POST'])
+            @flask_login.login_required
             def my_module_update():
                 # Perform update
                 return "Saved."

--- a/signac_dashboard/modules/document_editor.py
+++ b/signac_dashboard/modules/document_editor.py
@@ -4,6 +4,7 @@
 from ast import literal_eval
 from collections import OrderedDict
 
+import flask_login
 from flask import abort, render_template, request
 from jinja2.exceptions import TemplateNotFound
 from markupsafe import escape
@@ -60,6 +61,7 @@ class DocumentEditor(Module):
     def register(self, dashboard):
         # Register routes
         @dashboard.app.route("/module/document_editor/update", methods=["POST"])
+        @flask_login.login_required
         def document_editor_update():
             jobid = request.form.get("jobid")
             job = dashboard.project.open_job(id=jobid)
@@ -76,6 +78,7 @@ class DocumentEditor(Module):
             return "Saved."
 
         @dashboard.app.route("/module/document_editor/<path:filename>")
+        @flask_login.login_required
         def document_editor_asset(filename):
             path = f"document_editor/{filename}"
             try:

--- a/signac_dashboard/modules/notes.py
+++ b/signac_dashboard/modules/notes.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2022 The Regents of the University of Michigan
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
+import flask_login
 from flask import abort, render_template, request
 from jinja2.exceptions import TemplateNotFound
 
@@ -53,6 +54,7 @@ class Notes(Module):
     def register(self, dashboard):
         # Register routes
         @dashboard.app.route("/module/notes/update", methods=["POST"])
+        @flask_login.login_required
         def notes_update():
             note_text = request.form.get("note_text")
             jobid = request.form.get("jobid")
@@ -61,6 +63,7 @@ class Notes(Module):
             return "Saved."
 
         @dashboard.app.route("/module/notes/<path:filename>")
+        @flask_login.login_required
         def notes_asset(filename):
             path = f"notes/{filename}"
             try:

--- a/signac_dashboard/util.py
+++ b/signac_dashboard/util.py
@@ -2,9 +2,9 @@
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
 
+import flask_login
 from markupsafe import escape
 from werkzeug.utils import cached_property, import_string
-import flask_login
 
 
 def simplified_keys(project):

--- a/signac_dashboard/util.py
+++ b/signac_dashboard/util.py
@@ -4,6 +4,7 @@
 
 from markupsafe import escape
 from werkzeug.utils import cached_property, import_string
+import flask_login
 
 
 def simplified_keys(project):
@@ -56,5 +57,8 @@ class LazyView:
         return import_string(self.import_name)
 
     def __call__(self, *args, **kwargs):
+        if not flask_login.current_user.is_authenticated:
+            return self.dashboard.login_manager.unauthorized(), 401
+
         kwargs.update({"dashboard": self.dashboard})
         return self.view(*args, **kwargs)

--- a/signac_dashboard/util.py
+++ b/signac_dashboard/util.py
@@ -57,6 +57,7 @@ class LazyView:
         return import_string(self.import_name)
 
     def __call__(self, *args, **kwargs):
+        # Protect routes added in the format self.add_url("views.home", ["/"])
         if not flask_login.current_user.is_authenticated:
             return self.dashboard.login_manager.unauthorized(), 401
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -163,7 +163,7 @@ class AllModulesTestCase(DashboardTestCase):
         self.test_client = self.dashboard.app.test_client()
         self.addCleanup(shutil.rmtree, self._tmp_dir)
 
-    def test_login(self):
+    def test_login_with_None_token(self):
         rv = self.test_client.get("/login", follow_redirects=True)
         response = str(rv.get_data())
         assert "dashboard-test-project" in response

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -38,8 +38,18 @@ class DashboardTestCase(unittest.TestCase):
         self.test_client = self.dashboard.app.test_client()
         self.addCleanup(shutil.rmtree, self._tmp_dir)
 
+        # Test logged out content
+        rv = self.test_client.get("/", follow_redirects=True)
+        response = str(rv.get_data())
+        assert "Access token is required." in response
+
         # login
         self.test_client.get("/login?token=test", follow_redirects=True)
+
+    def test_invalid_token(self):
+        rv = self.test_client.get("/login?token=error", follow_redirects=True)
+        response = str(rv.get_data())
+        assert "Invalid token" in response
 
     def test_get_project(self):
         rv = self.test_client.get("/project/", follow_redirects=True)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -163,6 +163,11 @@ class AllModulesTestCase(DashboardTestCase):
         self.test_client = self.dashboard.app.test_client()
         self.addCleanup(shutil.rmtree, self._tmp_dir)
 
+    def test_login(self):
+        rv = self.test_client.get("/login", follow_redirects=True)
+        response = str(rv.get_data())
+        assert "dashboard-test-project" in response
+
     def test_module_visible_mobile(self):
         response = self.get_response("/jobs/?view=grid")
         # Check for two instances of Modules header

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -138,7 +138,7 @@ class AllModulesTestCase(DashboardTestCase):
                 job = self.project.open_job({"a": a, "b": b})
                 with job:
                     job.document["sum"] = a + b
-        self.config = {"ACCESS_TOKEN": "test"}
+        self.config = {"ACCESS_TOKEN": None}
         modules = []
         for m in signac_dashboard.modules.__all__:
             module = getattr(signac_dashboard.modules, m)
@@ -152,9 +152,6 @@ class AllModulesTestCase(DashboardTestCase):
         )
         self.test_client = self.dashboard.app.test_client()
         self.addCleanup(shutil.rmtree, self._tmp_dir)
-
-        # login
-        self.test_client.get("/login?token=test", follow_redirects=True)
 
     def test_module_visible_mobile(self):
         response = self.get_response("/jobs/?view=grid")

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -30,13 +30,16 @@ class DashboardTestCase(unittest.TestCase):
                 job = self.project.open_job({"a": a, "b": b})
                 with job:
                     job.document["sum"] = a + b
-        self.config = {}
+        self.config = {"ACCESS_TOKEN": "test"}
         self.modules = []
         self.dashboard = Dashboard(
             config=self.config, project=self.project, modules=self.modules
         )
         self.test_client = self.dashboard.app.test_client()
         self.addCleanup(shutil.rmtree, self._tmp_dir)
+
+        # login
+        self.test_client.get("/login?token=test", follow_redirects=True)
 
     def test_get_project(self):
         rv = self.test_client.get("/project/", follow_redirects=True)
@@ -135,7 +138,7 @@ class AllModulesTestCase(DashboardTestCase):
                 job = self.project.open_job({"a": a, "b": b})
                 with job:
                     job.document["sum"] = a + b
-        self.config = {}
+        self.config = {"ACCESS_TOKEN": "test"}
         modules = []
         for m in signac_dashboard.modules.__all__:
             module = getattr(signac_dashboard.modules, m)
@@ -149,6 +152,9 @@ class AllModulesTestCase(DashboardTestCase):
         )
         self.test_client = self.dashboard.app.test_client()
         self.addCleanup(shutil.rmtree, self._tmp_dir)
+
+        # login
+        self.test_client.get("/login?token=test", follow_redirects=True)
 
     def test_module_visible_mobile(self):
         response = self.get_response("/jobs/?view=grid")


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Description
<!-- Describe your changes in detail. -->
<!-- Please indicate if the changes may break existing functionality. -->
Following the model of Jupyter, generate a token when launched. Users must login with that token before they can view sensitive data. All routes are protected, except for static content.

This feature requires an additional dependency: `flask-login`: https://flask-login.readthedocs.io/ which appears to be the best maintained package for the job.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

On multi-user systems, anyone with access to the system can connect to servers running on open ports. This opens Dashboard user's projects to be read (and written to in the case of some modules) by anyone with access to the host system. 

This pull requests prevents that access. Like Jupyter, it generates a login token when invoked on the command line. Following the security guidelines in the documentation, users will receive this token over a secure SSH channel.
```
$ python3 dashboard.py run
/home/joaander/venv/lib/python3.10/site-packages/signac/contrib/project.py:95: FutureWarning: This method will soon become a property and should be used without the call operator (parentheses).
  warnings.warn(
To access this server, connect to: http://localhost:8888/login?token=<hidden>
 * Serving Flask app 'signac-dashboard'
 * Debug mode: off
WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
 * Running on http://localhost:8888
Press CTRL+C to quit
```

Other users that attempt to access the dashboard are greeted with:
<img width="1127" alt="image" src="https://user-images.githubusercontent.com/2197568/198351814-8f2e89f7-3bec-40ea-8dd0-92b94566926f.png">

In future work, we could add username/password authentication, where the user provides a hashed password in a config file.

Fixes #122 

## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-dashboard/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-dashboard/blob/master/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] The [package documentation](https://github.com/glotzerlab/signac-dashboard/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-dashboard/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.

## Documentation:

I will submit a request to update the framework documentation after this request is approved.