### PR TITLE
Show complete rows on pages by default.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,7 +7,7 @@ The **signac-dashboard** package follows `semantic versioning <https://semver.or
 Version 0.4
 ===========
 
-[0.4.0] -- xxxx-xx-xx
+[0.4.1] -- xxxx-xx-xx
 ---------------------
 
 Changed

--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,14 @@ The **signac-dashboard** package follows `semantic versioning <https://semver.or
 Version 0.4
 ===========
 
+[0.4.0] -- xxxx-xx-xx
+---------------------
+
+Changed
++++++++
+
+- Default value of ``PER_PAGE`` is now 24.
+
 [0.4.0] -- 2022-12-12
 ---------------------
 

--- a/signac_dashboard/dashboard.py
+++ b/signac_dashboard/dashboard.py
@@ -73,7 +73,7 @@ class Dashboard:
       :py:class:`werkzeug.middleware.profiler.ProfilerMiddleware` if
       :code:`True` (default: :code:`False`).
     - **PER_PAGE**: Maximum number of jobs to show per page
-      (default: 25).
+      (default: 24).
     - **CARDS_PER_ROW**: Cards to show per row in the desktop view. Must be a
       factor of 12 (default: 3).
     - **ACCESS_TOKEN**: The access token required to login to the dashboard.
@@ -116,7 +116,7 @@ class Dashboard:
         self.config.setdefault("DEBUG", False)
         self.config.setdefault("PORT", 8888)
         self.config.setdefault("PAGINATION", True)
-        self.config.setdefault("PER_PAGE", 25)
+        self.config.setdefault("PER_PAGE", 24)
         self.config.setdefault("CARDS_PER_ROW", 3)
         if 12 % self.config["CARDS_PER_ROW"] != 0:
             raise ValueError(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Description
<!-- Describe your changes in detail. -->
<!-- Please indicate if the changes may break existing functionality. -->
Set PER_PAGE to 24.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
With the default cards per row of 3, this makes the default view show complete rows to the end of the page. Prior to this change, the last row is left incomplete because 25 is not an integer multiple of 3.

## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-dashboard/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-dashboard/blob/master/ContributorAgreement.md).
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] The [package documentation](https://github.com/glotzerlab/signac-dashboard/tree/master/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-dashboard/blob/master/changelog.txt) and added any related issue and pull request numbers for future reference.
