### PR TITLE
Test Python 3.12.

### DIFF
--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -20,29 +20,42 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        config: [ {python: '3.8', dependencies: 'newest'},
-                  {python: '3.9', dependencies: 'newest'},
-                  {python: '3.10', dependencies: 'newest'},
-                  {python: '3.11', dependencies: 'newest'},
-                  {python: '3.11', dependencies: 'minimal'},
-                  {python: '3.8', dependencies: 'oldest'} ]
+        os: [ubuntu-latest]
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        include:
+          # Default to newest dependencies
+          - dependencies: 'newest'
+          # Test the oldest Python with the oldest supported dependencies.
+          - python: '3.8'
+            dependencies: 'oldest'
+          # Test the newest Python with both the newest and minimal dependencies.
+          - python: '3.12'
+            dependencies: 'newest'
+          - python: '3.12'
+            dependencies: 'minimal'
+          # Test macOS and windows only on latest version
+          - os: 'macos-latest'
+            python: '3.12'
+            dependencies: 'newest'
+          - os: 'windows-latest'
+            python: '3.12'
+            dependencies: 'newest'
     steps:
     - uses: actions/checkout@v3
       with:
         submodules: "recursive"
-    - name: Set up Python ${{ matrix.config.python }}
+    - name: Set up Python ${{ matrix.python }}
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.config.python }}
+        python-version: ${{ matrix.python }}
     - name: Install newest dependencies
       run: |
         pip install -r requirements/requirements-test.txt
-      if: ${{ matrix.config.dependencies == 'newest' }}
+      if: ${{ matrix.dependencies == 'newest' }}
     - name: Install minimal dependencies
       run: |
         pip install -r requirements/requirements-test.txt
-      if: ${{ matrix.config.dependencies == 'minimal' }}
+      if: ${{ matrix.dependencies == 'minimal' }}
     - name: Install oldest supported dependencies
       # To prevent Dependabot from updating the pinnings in this "oldest"
       # dependency list, we have to avoid the word "requirements" in the
@@ -50,7 +63,7 @@ jobs:
       # instead of "requirements."
       run: |
         pip install -r .github/workflows/ci-oldest-reqs.txt
-      if: ${{ matrix.config.dependencies == 'oldest' }}
+      if: ${{ matrix.dependencies == 'oldest' }}
     - name: Install the package
       run: |
         pip install -e .


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Description
<!-- Describe your changes in detail. -->
<!-- Please indicate if the changes may break existing functionality. -->
Test on Python 3.12. Also limit the number of jobs that run on limited macOS and windows runners.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
- Ensure that dashboard works with Python 3.12.
- Previously, the actions workflow ran the full matrix of tests on all 3 operating systems. This redundant testing adds significantly to the total time needed to test a push as GitHub Actions provides only a limited number of free macOS and Windows runners.

This PR limits macos and windows to 1 job each on the newest version of python and tests the full matrix on Linux.

## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-dashboard/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-dashboard/blob/main/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] The [package documentation](https://github.com/glotzerlab/signac-dashboard/tree/main/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-dashboard/blob/main/changelog.txt) and added any related issue and pull request numbers for future reference.
