### PR TITLE
Restore flask-login dependency pinning.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 dependencies = [
     "flask>=2.1.0",
     "flask-assets>=2.0.0",
-    "flask-login>=0.6.1",
+    "flask-login>=0.6.0",
     "flask-turbolinks",
     "jinja2>=3.0.0",
     "jsmin",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Description
<!-- Describe your changes in detail. -->
<!-- Please indicate if the changes may break existing functionality. -->
Set flask-login back to 0.6.0.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
See https://github.com/glotzerlab/signac-dashboard/pull/206#issuecomment-1806649569.

## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-dashboard/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-dashboard/blob/main/ContributorAgreement.md).
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] The [package documentation](https://github.com/glotzerlab/signac-dashboard/tree/main/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/signac-dashboard/blob/main/changelog.txt) and added any related issue and pull request numbers for future reference.
