### PR TITLE
Add a warning when capitalized booleans (improper JSON) appear in query

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,17 @@ Changes
 
 The **signac-dashboard** package follows `semantic versioning <https://semver.org/>`_.
 
+Version 0.7
+===========
+
+[0.7.0] -- 2024-xx-xx
+---------------------
+
+Updated
++++++
+
+- Feedback when querying for Python booleans instead of JSON booleans (#213).
+
 Version 0.6
 ===========
 

--- a/signac_dashboard/dashboard.py
+++ b/signac_dashboard/dashboard.py
@@ -374,11 +374,20 @@ class Dashboard:
                     f = json.loads(query)
                 except json.JSONDecodeError:
                     if "True" in query and "False" in query:
-                      flash("Interpreting \"True\" and \"False\" as strings. For boolean values use \"true\" and \"false\".", "warning")
+                        flash(
+                            'Interpreting "True" and "False" as strings. For boolean values use "true" and "false".',
+                            "warning",
+                        )
                     elif "True" in query:
-                        flash("Interpreting \"True\" as a string. For a boolean value use \"true\".", "warning")
+                        flash(
+                            'Interpreting "True" as a string. For a boolean value use "true".',
+                            "warning",
+                        )
                     elif "False" in query:
-                        flash("Interpreting \"False\" as a string. For a boolean value use \"false\".", "warning")
+                        flash(
+                            'Interpreting "False" as a string. For a boolean value use "false".',
+                            "warning",
+                        )
                     query = shlex.split(query)
                     f = signac.filterparse.parse_filter_arg(query)
                     flash(f"Search string interpreted as '{json.dumps(f)}'.")

--- a/signac_dashboard/dashboard.py
+++ b/signac_dashboard/dashboard.py
@@ -375,7 +375,7 @@ class Dashboard:
                 except json.JSONDecodeError:
                     if "True" in query and "False" in query:
                         flash(
-                            'Interpreting "True" and "False" as strings. For boolean values use "true" and "false".',
+                            'Interpreting "True" and "False" as strings. For boolean values use "true" and "false".',  # noqa:E501
                             "warning",
                         )
                     elif "True" in query:

--- a/signac_dashboard/dashboard.py
+++ b/signac_dashboard/dashboard.py
@@ -373,8 +373,12 @@ class Dashboard:
                 try:
                     f = json.loads(query)
                 except json.JSONDecodeError:
-                    if "True" in query or "False" in query:
-                        flash("JSON booleans are lowercase", "warning")
+                    if "True" in query and "False" in query:
+                      flash("Interpreting \"True\" and \"False\" as strings. For boolean values use \"true\" and \"false\".", "warning")
+                    elif "True" in query:
+                        flash("Interpreting \"True\" as a string. For a boolean value use \"true\".", "warning")
+                    elif "False" in query:
+                        flash("Interpreting \"False\" as a string. For a boolean value use \"false\".", "warning")
                     query = shlex.split(query)
                     f = signac.filterparse.parse_filter_arg(query)
                     flash(f"Search string interpreted as '{json.dumps(f)}'.")

--- a/signac_dashboard/dashboard.py
+++ b/signac_dashboard/dashboard.py
@@ -373,6 +373,8 @@ class Dashboard:
                 try:
                     f = json.loads(query)
                 except json.JSONDecodeError:
+                    if "True" in query or "False" in query:
+                        flash("JSON booleans are lowercase", "warning")
                     query = shlex.split(query)
                     f = signac.filterparse.parse_filter_arg(query)
                     flash(f"Search string interpreted as '{json.dumps(f)}'.")

--- a/signac_dashboard/dashboard.py
+++ b/signac_dashboard/dashboard.py
@@ -376,7 +376,7 @@ class Dashboard:
                     if "True" in query and "False" in query:
                         flash(
                             'Interpreting "True" and "False" as strings. For'
-							'boolean values use "true" and "false".',
+                            'boolean values use "true" and "false".',
                             "warning",
                         )
                     elif "True" in query:

--- a/signac_dashboard/dashboard.py
+++ b/signac_dashboard/dashboard.py
@@ -375,7 +375,8 @@ class Dashboard:
                 except json.JSONDecodeError:
                     if "True" in query and "False" in query:
                         flash(
-                            'Interpreting "True" and "False" as strings. For boolean values use "true" and "false".',  # noqa:E501
+                            'Interpreting "True" and "False" as strings. For'
+							'boolean values use "true" and "false".',
                             "warning",
                         )
                     elif "True" in query:


### PR DESCRIPTION
The warning from signac.filterparse._cast is burried in the shell and automatically searching for capitalized boolean string is likely not the expected result.

<!-- Provide a general summary of your changes in the title above. -->

## Description
<!-- Describe your changes in detail. -->
<!-- Please indicate if the changes may break existing functionality. -->

Make the feedback when searching for booleans in incorrect JSON more like `signac find`:
```
$ signac find a True
Did you mean true?
Interpreted filter arguments as '{"a": "True"}'.
```
<img width="700" alt="image" src="https://github.com/glotzerlab/signac-dashboard/assets/21282461/5a78a6b6-87c6-48ab-8f60-b5493d6847dd">

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

You would have to look at the shell to see these messages about casting of True-->true.

They come from `signac.filterparse._cast`

```shell
127.0.0.1 - - [14/Feb/2024 09:25:36] "POST /login HTTP/1.1" 302 -
Did you mean true?
Did you mean false?
Interpreted filter arguments as '{"a": "True"}'
```
Related to https://github.com/glotzerlab/signac-docs/pull/199

## Checklist:
<!-- This checklist must be complete before merging the pull request. -->
<!-- If you are unsure about any of these items, do not hesitate to ask! -->
- [x] I am familiar with the [Contributing Guidelines](https://github.com/glotzerlab/signac-dashboard/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [Contributor Agreement](https://github.com/glotzerlab/signac-dashboard/blob/main/ContributorAgreement.md).
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] The [package documentation](https://github.com/glotzerlab/signac-dashboard/tree/main/doc) and [framework documentation](https://docs.signac.io/) in [signac-docs](https://github.com/glotzerlab/signac-docs) are up to date with these changes.
- [x] I have updated the [changelog](https://github.com/glotzerlab/signac-dashboard/blob/main/changelog.txt) and added any related issue and pull request numbers for future reference.
